### PR TITLE
Fix build with gcc 5.4, x86_64.

### DIFF
--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -28,8 +28,8 @@
 
 #include "HeapStatistics.h"
 #include <algorithm>
+#include <cmath>
 #include <limits>
-#include <math.h>
 #include <mutex>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
- std::isnan isn't found in math.h, replace with cmath.
