### PR TITLE
Fixed possible NULL pointer crash.

### DIFF
--- a/Source/WebKit/haiku/API/WebFrame.cpp
+++ b/Source/WebKit/haiku/API/WebFrame.cpp
@@ -159,6 +159,8 @@ void BWebFrame::Reload()
 
 BString BWebFrame::URL() const
 {
+    if (fData->frame->document() == NULL)
+        return "";
     return fData->frame->document()->url().string();
 }
 


### PR DESCRIPTION
fData->frame->document() can return NULL in certain cases, causing a crash.