### PR TITLE
ExecutableAllocator: Fix the size of the executable pool to 32MB.

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -90,6 +90,10 @@ extern "C" {
 namespace JSC {
 
 using namespace WTF;
+    
+#if defined(__HAIKU__) && !CPU(
+#define FIXED_EXECUTABLE_MEMORY_POOL_SIZE_IN_MB 32
+#endif
 
 #if defined(FIXED_EXECUTABLE_MEMORY_POOL_SIZE_IN_MB) && FIXED_EXECUTABLE_MEMORY_POOL_SIZE_IN_MB > 0
 static const size_t fixedExecutableMemoryPoolSize = FIXED_EXECUTABLE_MEMORY_POOL_SIZE_IN_MB * 1024 * 1024;

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -91,7 +91,7 @@ namespace JSC {
 
 using namespace WTF;
     
-#if defined(__HAIKU__) && !CPU(
+#if defined(__HAIKU__)
 #define FIXED_EXECUTABLE_MEMORY_POOL_SIZE_IN_MB 32
 #endif
 


### PR DESCRIPTION
The x86_64 default was 1GB, which winds up wasting a *huge*
amount of (non-overcommitting) memory on Haiku. 32MB is the
current default on 32-bit, so this is probably fine for everywhere.