### PR TITLE
Adaption of WebKit to the changes to Services Kit

### DIFF
--- a/Source/WebCore/platform/graphics/haiku/MediaPlayerPrivateHaiku.cpp
+++ b/Source/WebCore/platform/graphics/haiku/MediaPlayerPrivateHaiku.cpp
@@ -35,8 +35,6 @@
 #include <MediaFile.h>
 #include <MediaTrack.h>
 #include <SoundPlayer.h>
-#include <UrlProtocolRoster.h>
-#include <UrlRequest.h>
 #include <View.h>
 
 namespace WebCore {
@@ -62,7 +60,7 @@ private:
 
     bool supportsKeySystem(const String& keySystem, const String& mimeType) const final
     {
-		return false;
+        return false;
         //return MediaPlayerPrivate::supportsKeySystem(keySystem, mimeType);
     }
 };
@@ -92,11 +90,11 @@ MediaPlayerPrivate::~MediaPlayerPrivate()
 {
     delete m_soundPlayer;
 
-	m_mediaLock.Lock();
+    m_mediaLock.Lock();
 
     cancelLoad();
     delete m_frameBuffer;
-	m_mediaLock.Unlock();
+    m_mediaLock.Unlock();
 }
 
 #if ENABLE(MEDIA_SOURCE)
@@ -113,10 +111,10 @@ void MediaPlayerPrivate::load(const String& url)
         m_soundPlayer->Stop(false);
     delete m_soundPlayer;
 
-	m_mediaLock.Lock();
+    m_mediaLock.Lock();
     cancelLoad();
 
-	m_mediaLock.Unlock();
+    m_mediaLock.Unlock();
 
     // TODO we need more detailed info from the BMediaFile to accurately report
     // the m_readyState and the m_networkState to WebKit. The API will need to
@@ -143,12 +141,12 @@ void MediaPlayerPrivate::load(const String& url)
 
 void MediaPlayerPrivate::cancelLoad()
 {
-	m_mediaLock.Lock();
+    m_mediaLock.Lock();
     delete m_mediaFile;
     m_mediaFile = nullptr;
-	m_audioTrack = nullptr;
-	m_videoTrack = nullptr;
-	m_mediaLock.Unlock();
+    m_audioTrack = nullptr;
+    m_videoTrack = nullptr;
+    m_mediaLock.Unlock();
 }
 
 void MediaPlayerPrivate::prepareToPlay()
@@ -161,42 +159,42 @@ void MediaPlayerPrivate::playCallback(void* cookie, void* buffer,
 {
     MediaPlayerPrivate* player = (MediaPlayerPrivate*)cookie;
 
-	if (!player->m_mediaLock.Lock())
-		return;
+    if (!player->m_mediaLock.Lock())
+        return;
 
     // Deleting the BMediaFile release the tracks
     if (player->m_audioTrack) {
-		// TODO handle the case where there is a video, but no audio track.
-		player->m_currentTime = player->m_audioTrack->CurrentTime() / 1000000.f;
+        // TODO handle the case where there is a video, but no audio track.
+        player->m_currentTime = player->m_audioTrack->CurrentTime() / 1000000.f;
 
-		int64 size64;
-		if (player->m_audioTrack->ReadFrames(buffer, &size64) != B_OK)
-		{
-			// Notify that we're done playing...
-			player->m_currentTime = player->m_audioTrack->Duration() / 1000000.f;
-			player->m_soundPlayer->Stop(false);
+        int64 size64;
+        if (player->m_audioTrack->ReadFrames(buffer, &size64) != B_OK)
+        {
+            // Notify that we're done playing...
+            player->m_currentTime = player->m_audioTrack->Duration() / 1000000.f;
+            player->m_soundPlayer->Stop(false);
 
-			WeakPtr<MediaPlayerPrivate> p = makeWeakPtr(player);
-			callOnMainThread([p] {
-				if (!p)
-                	return;
-				p->m_player->timeChanged();
-			});
+            WeakPtr<MediaPlayerPrivate> p = makeWeakPtr(player);
+            callOnMainThread([p] {
+                if (!p)
+                    return;
+                p->m_player->timeChanged();
+            });
 
-			player->m_audioTrack = nullptr;
-    	}
-	}
+            player->m_audioTrack = nullptr;
+        }
+    }
 
     if (player->m_videoTrack && player->m_audioTrack) {
-        if (player->m_videoTrack->CurrentTime() 
+        if (player->m_videoTrack->CurrentTime()
             < player->m_audioTrack->CurrentTime())
         {
             // Decode a video frame and show it on screen
             int64 count;
             if (player->m_videoTrack->ReadFrames(player->m_frameBuffer->Bits(),
                 &count) != B_OK) {
-				player->m_videoTrack = nullptr;
-			}
+                player->m_videoTrack = nullptr;
+            }
 
             WeakPtr<MediaPlayerPrivate> p = makeWeakPtr(player);
             callOnMainThread([p] {
@@ -206,7 +204,7 @@ void MediaPlayerPrivate::playCallback(void* cookie, void* buffer,
             });
         }
     }
-	player->m_mediaLock.Unlock();
+    player->m_mediaLock.Unlock();
 }
 
 void MediaPlayerPrivate::play()
@@ -286,7 +284,7 @@ bool MediaPlayerPrivate::seeking() const
     notImplemented();
     return false;
 }
- 
+
 bool MediaPlayerPrivate::paused() const
 {
     return m_paused;

--- a/Source/WebCore/platform/graphics/haiku/MediaPlayerPrivateHaiku.h
+++ b/Source/WebCore/platform/graphics/haiku/MediaPlayerPrivateHaiku.h
@@ -34,7 +34,6 @@ class BDataIO;
 class BMediaFile;
 class BMediaTrack;
 class BSoundPlayer;
-class BUrlRequest;
 struct media_raw_audio_format;
 
 namespace WebCore {
@@ -42,9 +41,9 @@ namespace WebCore {
 class MediaPlayerFactoryHaiku;
 
 class MediaPlayerPrivate : public MediaPlayerPrivateInterface,
-	public CanMakeWeakPtr<MediaPlayerPrivate> {
+    public CanMakeWeakPtr<MediaPlayerPrivate> {
     public:
-		friend class MediaPlayerFactoryHaiku;
+        friend class MediaPlayerFactoryHaiku;
 
         static void registerMediaEngine(MediaEngineRegistrar);
 
@@ -92,7 +91,7 @@ class MediaPlayerPrivate : public MediaPlayerPrivateInterface,
         void paint(GraphicsContext&, const FloatRect&) override;
 
     private:
-        
+
         void IdentifyTracks(const String& url);
 
         static void playCallback(void*, void*, size_t,
@@ -108,7 +107,7 @@ class MediaPlayerPrivate : public MediaPlayerPrivateInterface,
         BMediaTrack* m_videoTrack;
         BSoundPlayer* m_soundPlayer;
         BBitmap* m_frameBuffer;
-		BLocker m_mediaLock;
+        BLocker m_mediaLock;
 
         MediaPlayer* m_player;
         MediaPlayer::NetworkState m_networkState;

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -41,7 +41,7 @@
 #if PLATFORM(COCOA) || USE(CFURLCONNECTION)
 #include <wtf/RetainPtr.h>
 #elif PLATFORM(HAIKU)
-class BUrlContext;
+class BUrlSession;
 #endif
 
 #if PLATFORM(COCOA)
@@ -145,8 +145,8 @@ public:
     WEBCORE_EXPORT NetworkStorageSession(PAL::SessionID);
     ~NetworkStorageSession();
 
-    BUrlContext& platformSession() const;
-    void setPlatformSession(BUrlContext*);
+    BUrlSession& platformSession() const;
+    void setPlatformSession(BUrlSession*);
 #elif USE(CURL)
     WEBCORE_EXPORT NetworkStorageSession(PAL::SessionID);
     ~NetworkStorageSession();
@@ -252,7 +252,7 @@ private:
     GRefPtr<SoupCookieJar> m_cookieStorage;
     Function<void ()> m_cookieObserverHandler;
 #elif USE(HAIKU)
-    BUrlContext* m_context;
+    BUrlSession* m_context;
 #elif USE(CURL)
     mutable UniqueRef<CookieJarDB> m_cookieDatabase;
 #else

--- a/Source/WebCore/platform/network/ResourceHandleInternal.h
+++ b/Source/WebCore/platform/network/ResourceHandleInternal.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -82,7 +82,7 @@ public:
         , m_currentRequest(request)
 #endif
 #if PLATFORM(HAIKU)
-		, m_urlrequest(0)
+        , m_urlrequest(0)
 #endif
         , m_failureTimer(*loader, &ResourceHandle::failureTimerFired)
     {
@@ -91,7 +91,7 @@ public:
         m_password = url.password();
         m_firstRequest.removeCredentials();
     }
-    
+
     ~ResourceHandleInternal();
 
     ResourceHandleClient* client() { return m_client; }
@@ -105,9 +105,9 @@ public:
     // Suggested credentials for the current redirection step.
     String m_user;
     String m_password;
-    
+
     Credential m_initialCredential;
-    
+
     int status { 0 };
 
     bool m_defersLoading;
@@ -130,7 +130,7 @@ public:
 #endif
 #if USE(CURL)
     std::unique_ptr<CurlResourceHandleDelegate> m_delegate;
-    
+
     bool m_cancelled { false };
     unsigned m_redirectCount { 0 };
     unsigned m_authFailureCount { 0 };
@@ -141,8 +141,8 @@ public:
 #endif
 
 #if PLATFORM(HAIKU)
-		BUrlProtocolHandler* m_urlrequest;
-		BString	m_url;
+    BUrlProtocolHandler* m_urlrequest;
+    BString m_url;
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/network/haiku/BUrlProtocolHandler.h
+++ b/Source/WebCore/platform/network/haiku/BUrlProtocolHandler.h
@@ -21,6 +21,7 @@
 
 #include "HaikuFormDataStream.h"
 #include "ResourceRequest.h"
+#include "ResourceError.h"
 
 #include <support/Locker.h>
 #include <Messenger.h>
@@ -32,41 +33,67 @@ class BFile;
 namespace WebCore {
 
 class NetworkingContext;
+class NetworkStorageSession;
 class ResourceHandle;
 class ResourceResponse;
 
-class BUrlProtocolHandler : public BUrlProtocolAsynchronousListener
-{
+class BUrlProtocolHandler;
+
+class BUrlRequestWrapper : public RefCounted<BUrlRequestWrapper>, public BUrlProtocolAsynchronousListener {
 public:
-    BUrlProtocolHandler(NetworkingContext* context, ResourceHandle *handle, 
-        bool synchronous);
-    virtual ~BUrlProtocolHandler();
+    static RefPtr<BUrlRequestWrapper> create(BUrlProtocolHandler*, NetworkStorageSession*, ResourceRequest&);
+    virtual ~BUrlRequestWrapper();
+
     void abort();
 
-    bool isValid() { return m_request != NULL; }
+    bool isValid() const { return m_request; };
 
-private:
-    void AuthenticationNeeded(BHttpRequest* caller, ResourceResponse& response);
-
-    // BUrlListener hooks
-    void ConnectionOpened(BUrlRequest* caller) override;
-    void HeadersReceived(BUrlRequest* caller, const BUrlResult& result) override;
-    void DataReceived(BUrlRequest* caller, const char* data, off_t position,
-        ssize_t size) override;
+    // BUrlProtocolListener hooks
+    void HeadersReceived(BUrlRequest* caller, const BUrlResult&) override;
+    void DataReceived(BUrlRequest* caller, const char* data, off_t position, ssize_t) override;
     void UploadProgress(BUrlRequest* caller, ssize_t bytesSent, ssize_t bytesTotal) override;
     void RequestCompleted(BUrlRequest* caller, bool success) override;
-    bool CertificateVerificationFailed(BUrlRequest* caller, BCertificate& certificate, const char* message) override;
+    bool CertificateVerificationFailed(BUrlRequest* caller, BCertificate&, const char* message) override;
 
 private:
-    ResourceHandle* m_resourceHandle;
-    bool m_redirected;
-    bool m_responseDataSent;
-    BFormDataIO* m_postData;
-    BUrlRequest* m_request;
-    off_t m_position;
-    URL m_baseUrl;
+    BUrlRequestWrapper(BUrlProtocolHandler*, NetworkStorageSession*, ResourceRequest&);
 
-    int m_redirectionTries;
+private:
+    BUrlProtocolHandler* m_handler { nullptr };
+    BUrlRequest* m_request { nullptr };
+
+    bool m_didReceiveData { false };
+};
+
+class BUrlProtocolHandler {
+public:
+    explicit BUrlProtocolHandler(ResourceHandle *handle);
+    virtual ~BUrlProtocolHandler();
+
+    void abort();
+
+    bool isValid() const { return m_request && m_request->isValid(); }
+
+private:
+    void didFail(const ResourceError& error);
+    void willSendRequest(const ResourceResponse& response);
+    void continueAfterWillSendRequest(ResourceRequest&& request);
+    bool didReceiveAuthenticationChallenge(const ResourceResponse& response);
+    void didReceiveResponse(ResourceResponse&& response);
+    void didReceiveData(const char* data, size_t);
+    void didSendData(ssize_t bytesSent, ssize_t bytesTotal);
+    void didFinishLoading();
+    bool didReceiveInvalidCertificate(BCertificate&, const char* message);
+
+private:
+    friend class BUrlRequestWrapper;
+
+    ResourceRequest m_resourceRequest;
+    ResourceHandle* m_resourceHandle;
+    RefPtr<BUrlRequestWrapper> m_request;
+
+    unsigned m_redirectionTries { 0 };
+    unsigned m_authenticationTries { 0 };
 };
 
 }

--- a/Source/WebCore/platform/network/haiku/NetworkStorageSessionHaiku.cpp
+++ b/Source/WebCore/platform/network/haiku/NetworkStorageSessionHaiku.cpp
@@ -28,7 +28,7 @@
 #include "NetworkStorageSession.h"
 
 #include <support/Locker.h>
-#include <UrlContext.h>
+#include <UrlSession.h>
 
 #include "Cookie.h"
 #include "CookieRequestHeaderFieldProxy.h"
@@ -63,19 +63,19 @@ static std::unique_ptr<NetworkStorageSession>& defaultSession()
 }
 
 void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty,
-	const SameSiteInfo& sameSiteInfo, const URL& url,
-	WTF::Optional<FrameIdentifier> frameID, WTF::Optional<PageIdentifier> pageID,
-	ShouldAskITP, const String& value, ShouldRelaxThirdPartyCookieBlocking) const
+    const SameSiteInfo& sameSiteInfo, const URL& url,
+    WTF::Optional<FrameIdentifier> frameID, WTF::Optional<PageIdentifier> pageID,
+    ShouldAskITP, const String& value, ShouldRelaxThirdPartyCookieBlocking) const
 {
-	BNetworkCookie* heapCookie
-		= new BNetworkCookie(value, BUrl(url));
+    BNetworkCookie* heapCookie
+        = new BNetworkCookie(value, BUrl(url));
 
 #if TRACE_COOKIE_JAR
-	printf("CookieJar: Add %s for %s\n", heapCookie->RawCookie(true).String(),
+    printf("CookieJar: Add %s for %s\n", heapCookie->RawCookie(true).String(),
         url.string().utf8().data());
-	printf("  from %s\n", value.utf8().data());
+    printf("  from %s\n", value.utf8().data());
 #endif
-	platformSession().GetCookieJar().AddCookie(heapCookie);
+    platformSession().GetCookieJar().AddCookie(heapCookie);
 }
 
 HTTPCookieAcceptPolicy NetworkStorageSession::cookieAcceptPolicy() const
@@ -84,39 +84,39 @@ HTTPCookieAcceptPolicy NetworkStorageSession::cookieAcceptPolicy() const
 }
 
 std::pair<String, bool> NetworkStorageSession::cookiesForDOM(const URL& firstParty,
-	const SameSiteInfo& sameSiteInfo, const URL& url,
-	WTF::Optional<FrameIdentifier> frameID, WTF::Optional<PageIdentifier> pageID,
-	IncludeSecureCookies includeSecureCookies, ShouldAskITP,
-	ShouldRelaxThirdPartyCookieBlocking) const
+    const SameSiteInfo& sameSiteInfo, const URL& url,
+    WTF::Optional<FrameIdentifier> frameID, WTF::Optional<PageIdentifier> pageID,
+    IncludeSecureCookies includeSecureCookies, ShouldAskITP,
+    ShouldRelaxThirdPartyCookieBlocking) const
 {
 #if TRACE_COOKIE_JAR
-	printf("CookieJar: Request for %s\n", url.string().utf8().data());
+    printf("CookieJar: Request for %s\n", url.string().utf8().data());
 #endif
 
-	BString result;
-	BUrl hUrl(url);
-	bool secure = false;
+    BString result;
+    BUrl hUrl(url);
+    bool secure = false;
 
-	const BNetworkCookie* c;
-	for (BNetworkCookieJar::UrlIterator it(
+    const BNetworkCookie* c;
+    for (BNetworkCookieJar::UrlIterator it(
             platformSession().GetCookieJar().GetUrlIterator(hUrl));
-		    (c = it.Next()); ) {
+            (c = it.Next()); ) {
         // filter out httpOnly cookies,as this method is used to get cookies
         // from JS code and these shouldn't be visible there.
         if(c->HttpOnly())
-			continue;
+            continue;
 
-		// filter out secure cookies if they should be
-		if (c->Secure())
-		{
-			secure = true;
+        // filter out secure cookies if they should be
+        if (c->Secure())
+        {
+            secure = true;
             if (includeSecureCookies == IncludeSecureCookies::No)
-				continue;
-		}
-		
-		result << "; " << c->RawCookie(false);
-	}
-	result.Remove(0, 2);
+                continue;
+        }
+
+        result << "; " << c->RawCookie(false);
+    }
+    result.Remove(0, 2);
 
     return {result, secure};
 }
@@ -139,9 +139,9 @@ void NetworkStorageSession::deleteCookie(const Cookie&)
 void NetworkStorageSession::deleteCookie(const URL& url, const String& cookie) const
 {
 #if TRACE_COOKIE_JAR
-	printf("CookieJar: delete cookie for %s (NOT IMPLEMENTED)\n", url.string().utf8().data());
+    printf("CookieJar: delete cookie for %s (NOT IMPLEMENTED)\n", url.string().utf8().data());
 #endif
-	notImplemented();
+    notImplemented();
 }
 
 void NetworkStorageSession::deleteAllCookies()
@@ -177,13 +177,13 @@ Vector<Cookie> NetworkStorageSession::getCookies(const URL&)
 }
 
 bool NetworkStorageSession::getRawCookies(const URL& firstParty,
-	const SameSiteInfo& sameSiteInfo, const URL& url, WTF::Optional<FrameIdentifier> frameID,
-	WTF::Optional<PageIdentifier> pageID, ShouldAskITP, ShouldRelaxThirdPartyCookieBlocking, Vector<Cookie>& rawCookies) const
+    const SameSiteInfo& sameSiteInfo, const URL& url, WTF::Optional<FrameIdentifier> frameID,
+    WTF::Optional<PageIdentifier> pageID, ShouldAskITP, ShouldRelaxThirdPartyCookieBlocking, Vector<Cookie>& rawCookies) const
 {
 #if TRACE_COOKIE_JAR
-	printf("CookieJar: get raw cookies for %s (NOT IMPLEMENTED)\n", url.string().utf8().data());
+    printf("CookieJar: get raw cookies for %s (NOT IMPLEMENTED)\n", url.string().utf8().data());
 #endif
-	notImplemented();
+    notImplemented();
 
     rawCookies.clear();
     return false; // return true when implemented
@@ -195,33 +195,33 @@ void NetworkStorageSession::flushCookieStore()
 }
 
 std::pair<String, bool> NetworkStorageSession::cookieRequestHeaderFieldValue(const URL& firstParty,
-	const SameSiteInfo& sameSiteInfo, const URL& url, WTF::Optional<FrameIdentifier> frameID,
-	WTF::Optional<PageIdentifier> pageID, IncludeSecureCookies includeSecureCookies, ShouldAskITP,
-	ShouldRelaxThirdPartyCookieBlocking) const
+    const SameSiteInfo& sameSiteInfo, const URL& url, WTF::Optional<FrameIdentifier> frameID,
+    WTF::Optional<PageIdentifier> pageID, IncludeSecureCookies includeSecureCookies, ShouldAskITP,
+    ShouldRelaxThirdPartyCookieBlocking) const
 {
 #if TRACE_COOKIE_JAR
-	printf("CookieJar: RequestHeaderField for %s\n", url.string().utf8().data());
+    printf("CookieJar: RequestHeaderField for %s\n", url.string().utf8().data());
 #endif
 
-	BString result;
-	BUrl hUrl(url);
-	bool secure = false;
+    BString result;
+    BUrl hUrl(url);
+    bool secure = false;
 
-	const BNetworkCookie* c;
-	for (BNetworkCookieJar::UrlIterator it(
-        	platformSession().GetCookieJar().GetUrlIterator(hUrl));
-		    (c = it.Next()); ) {
-		// filter out secure cookies if they should be
-		if (c->Secure())
-		{
-			secure = true;
+    const BNetworkCookie* c;
+    for (BNetworkCookieJar::UrlIterator it(
+            platformSession().GetCookieJar().GetUrlIterator(hUrl));
+            (c = it.Next()); ) {
+        // filter out secure cookies if they should be
+        if (c->Secure())
+        {
+            secure = true;
             if (includeSecureCookies == IncludeSecureCookies::No)
-				continue;
-		}
-		
-		result << "; " << c->RawCookie(false);
-	}
-	result.Remove(0, 2);
+                continue;
+        }
+
+        result << "; " << c->RawCookie(false);
+    }
+    result.Remove(0, 2);
 
     return {result, secure};
 }
@@ -236,13 +236,17 @@ std::pair<String, bool> NetworkStorageSession::cookieRequestHeaderFieldValue(
         ShouldRelaxThirdPartyCookieBlocking::No);
 }
 
-BUrlContext& NetworkStorageSession::platformSession() const
+BUrlSession& NetworkStorageSession::platformSession() const
 {
-    static BUrlContext sDefaultContext;
-    return m_context ? *m_context : sDefaultContext;
+    static BUrlSession sDefaultSession;
+    if (sDefaultSession.InitCheck() != B_OK) {
+        // TODO: Handle this somehow? or just throw std::bad_alloc?
+        abort();
+    }
+    return m_context ? *m_context : sDefaultSession;
 }
 
-void NetworkStorageSession::setPlatformSession(BUrlContext* context)
+void NetworkStorageSession::setPlatformSession(BUrlSession* context)
 {
     m_context = context;
 }

--- a/Source/WebCore/platform/network/haiku/ResourceRequest.h
+++ b/Source/WebCore/platform/network/haiku/ResourceRequest.h
@@ -32,7 +32,7 @@
 #include <String.h>
 #include <Referenceable.h>
 
-class BUrlContext;
+class BUrlSession;
 class BUrlRequest;
 
 namespace WebCore {
@@ -60,7 +60,7 @@ namespace WebCore {
         {
         }
 
-        BUrlRequest* toNetworkRequest(BUrlContext*);
+        BUrlRequest* toNetworkRequest(BUrlSession*);
 
         void setCredentials(const char* username, const char* password);
         void updateFromDelegatePreservingOldProperties(const ResourceRequest& delegateProvidedRequest) { *this = delegateProvidedRequest; }

--- a/Source/WebCore/platform/network/haiku/ResourceRequestHaiku.cpp
+++ b/Source/WebCore/platform/network/haiku/ResourceRequestHaiku.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 
 BUrlRequest* ResourceRequest::toNetworkRequest(BUrlContext* context)
 {
-    BUrlRequest* request = BUrlProtocolRoster::MakeRequest(url());
+    BUrlRequest* request = BUrlProtocolRoster::MakeRequest(url(), nullptr);
 
     if (!request) {
         m_url = WTF::aboutBlankURL(); // This tells the ResourceLoader we failed.

--- a/Source/WebCore/platform/network/haiku/ResourceRequestHaiku.cpp
+++ b/Source/WebCore/platform/network/haiku/ResourceRequestHaiku.cpp
@@ -24,7 +24,7 @@
 #include "NetworkingContext.h"
 
 #include <support/Locker.h>
-#include <UrlProtocolRoster.h>
+#include <UrlSession.h>
 #include <UrlRequest.h>
 #include <HttpRequest.h>
 #include <LocaleRoster.h>
@@ -32,17 +32,19 @@
 
 namespace WebCore {
 
-BUrlRequest* ResourceRequest::toNetworkRequest(BUrlContext* context)
+BUrlRequest* ResourceRequest::toNetworkRequest(BUrlSession* session)
 {
-    BUrlRequest* request = BUrlProtocolRoster::MakeRequest(url(), nullptr);
+    if (!session) {
+        m_url = WTF::aboutBlankURL();
+        return NULL;
+    }
+
+    BUrlRequest* request = session->MakeRequest(url(), nullptr);
 
     if (!request) {
         m_url = WTF::aboutBlankURL(); // This tells the ResourceLoader we failed.
         return NULL;
     }
-
-    if (context)
-        request->SetContext(context);
 
     if (timeoutInterval() > 0)
         request->SetTimeout(timeoutInterval());

--- a/Source/WebKitLegacy/haiku/API/WebPage.cpp
+++ b/Source/WebKitLegacy/haiku/API/WebPage.cpp
@@ -235,12 +235,12 @@ class MediaRecorderProviderHaiku: public MediaRecorderProvider
 };
 
 
-BWebPage::BWebPage(BWebView* webView, BUrlContext* context)
+BWebPage::BWebPage(BWebView* webView, BUrlSession* session)
     : BHandler("BWebPage")
     , fWebView(webView)
     , fMainFrame(NULL)
     , fSettings(NULL)
-    , fContext(context)
+    , fSession(session)
     , fPage(NULL)
     , fDumpRenderTree(NULL)
     , fLoadingProgress(100)
@@ -364,9 +364,9 @@ void BWebPage::SetDownloadListener(const BMessenger& listener)
     sDownloadListener = listener;
 }
 
-BUrlContext* BWebPage::GetContext()
+BUrlSession* BWebPage::GetSession()
 {
-    return fContext;
+    return fSession;
 }
 
 void BWebPage::LoadURL(const char* urlString)

--- a/Source/WebKitLegacy/haiku/API/WebPage.h
+++ b/Source/WebKitLegacy/haiku/API/WebPage.h
@@ -36,7 +36,7 @@
 
 class BNetworkCookieJar;
 class BRegion;
-class BUrlContext;
+class BUrlSession;
 class BView;
 class BWebDownload;
 class BWebFrame;
@@ -128,7 +128,7 @@ private:
 	friend class BWebView;
 	friend class BPrivate::WebDownloadPrivate;
 
-								BWebPage(BWebView* webView, BUrlContext* context);
+								BWebPage(BWebView* webView, BUrlSession* session);
 
 	// These calls are private, since they are called from the BWebView only.
 	void setVisible(bool visible);
@@ -164,7 +164,7 @@ private:
         bool modalDialog = false, bool resizable = true,
         bool activate = true);
 
-    BUrlContext* GetContext();
+    BUrlSession* GetSession();
     BRect windowFrame();
     BRect windowBounds();
     void setWindowBounds(const BRect& bounds);
@@ -233,7 +233,7 @@ private:
 			BWebView*			fWebView;
 			BWebFrame*			fMainFrame;
 			BWebSettings*		fSettings;
-            BUrlContext*        fContext;
+            BUrlSession*        fSession;
 			WebCore::Page*		fPage;
             WebCore::DumpRenderTreeClient* fDumpRenderTree;
 

--- a/Source/WebKitLegacy/haiku/API/WebSettings.cpp
+++ b/Source/WebKitLegacy/haiku/API/WebSettings.cpp
@@ -46,7 +46,6 @@
 #include <Font.h>
 #include <Path.h>
 #include <stdio.h>
-#include <UrlContext.h>
 
 enum {
 	HANDLE_SET_PERSISTENT_STORAGE_PATH = 'hspp',
@@ -524,7 +523,7 @@ void BWebSettings::_HandleSetProxyInfo(BMessage* message)
     // TODO there could be a cleaner way of accessing the default context from here.
     RefPtr<WebCore::FrameNetworkingContextHaiku> context
         = WebCore::FrameNetworkingContextHaiku::create(nullptr, nullptr);
-    context->context()->SetProxy(host, port);
+    context->session()->SetProxy(host, port);
 }
 
 void BWebSettings::_HandleApply()

--- a/Source/WebKitLegacy/haiku/API/WebView.cpp
+++ b/Source/WebKitLegacy/haiku/API/WebView.cpp
@@ -62,7 +62,7 @@ BWebView::UserData::~UserData()
 }
 
 
-BWebView::BWebView(const char* name, BUrlContext* urlContext)
+BWebView::BWebView(const char* name, BUrlSession* urlSession)
     : BView(name, B_WILL_DRAW | B_FRAME_EVENTS | B_FULL_UPDATE_ON_RESIZE
     	| B_NAVIGABLE | B_PULSE_NEEDED)
     , fLastMouseButtons(0)
@@ -71,7 +71,7 @@ BWebView::BWebView(const char* name, BUrlContext* urlContext)
     , fAutoHidePointer(false)
     , fOffscreenBitmap(nullptr)
     , fOffscreenView(nullptr)
-    , fWebPage(new BWebPage(this, urlContext))
+    , fWebPage(new BWebPage(this, urlSession))
     , fUserData(nullptr)
 {
 #if USE(TEXTURE_MAPPER)

--- a/Source/WebKitLegacy/haiku/API/WebView.h
+++ b/Source/WebKitLegacy/haiku/API/WebView.h
@@ -34,7 +34,7 @@
 
 #include <memory>
 
-class BUrlContext;
+class BUrlSession;
 class BWebPage;
 
 namespace WebCore {
@@ -53,7 +53,7 @@ public:
 	};
 
 public:
-								BWebView(const char* name, BUrlContext* context = nullptr);
+								BWebView(const char* name, BUrlSession* session = nullptr);
 	virtual						~BWebView();
 
 	// The BWebView needs to be deleted by the BWebPage instance running

--- a/Source/WebKitLegacy/haiku/WebCoreSupport/FrameLoaderClientHaiku.cpp
+++ b/Source/WebKitLegacy/haiku/WebCoreSupport/FrameLoaderClientHaiku.cpp
@@ -1002,7 +1002,7 @@ void FrameLoaderClientHaiku::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld
 
 Ref<FrameNetworkingContext> FrameLoaderClientHaiku::createNetworkingContext()
 {
-    return FrameNetworkingContextHaiku::create(m_webFrame->Frame(), m_webPage->GetContext());
+    return FrameNetworkingContextHaiku::create(m_webFrame->Frame(), m_webPage->GetSession());
 }
 
 // #pragma mark - private

--- a/Source/WebKitLegacy/haiku/WebCoreSupport/FrameNetworkingContextHaiku.cpp
+++ b/Source/WebKitLegacy/haiku/WebCoreSupport/FrameNetworkingContextHaiku.cpp
@@ -36,7 +36,7 @@
 #include "Page.h"
 #include "ResourceHandle.h"
 
-#include <UrlContext.h>
+#include <UrlSession.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
@@ -47,22 +47,22 @@ static std::unique_ptr<NetworkStorageSession>& privateSession()
     return session;
 }
 
-Ref<FrameNetworkingContextHaiku> FrameNetworkingContextHaiku::create(Frame* frame, BUrlContext* context)
+Ref<FrameNetworkingContextHaiku> FrameNetworkingContextHaiku::create(Frame* frame, BUrlSession* session)
 {
-    return adoptRef(*new FrameNetworkingContextHaiku(frame, context));
+    return adoptRef(*new FrameNetworkingContextHaiku(frame, session));
 }
 
-FrameNetworkingContextHaiku::FrameNetworkingContextHaiku(Frame* frame, BUrlContext* context)
+FrameNetworkingContextHaiku::FrameNetworkingContextHaiku(Frame* frame, BUrlSession* session)
     : FrameNetworkingContext(frame)
 {
-    storageSession()->setPlatformSession(context);
+    storageSession()->setPlatformSession(session);
 }
 
 FrameNetworkingContextHaiku::~FrameNetworkingContextHaiku()
 {
 }
 
-BUrlContext* FrameNetworkingContextHaiku::context()
+BUrlSession* FrameNetworkingContextHaiku::session()
 {
     return &storageSession()->platformSession();
 }

--- a/Source/WebKitLegacy/haiku/WebCoreSupport/FrameNetworkingContextHaiku.h
+++ b/Source/WebKitLegacy/haiku/WebCoreSupport/FrameNetworkingContextHaiku.h
@@ -33,22 +33,22 @@
 
 #include <support/Locker.h>
 #include <Referenceable.h>
-#include <UrlContext.h>
+#include <UrlSession.h>
 
 namespace WebCore {
 
 class FrameNetworkingContextHaiku : public WebCore::FrameNetworkingContext {
 public:
-    static Ref<FrameNetworkingContextHaiku> create(Frame*, BUrlContext* context);
+    static Ref<FrameNetworkingContextHaiku> create(Frame*, BUrlSession*);
     virtual ~FrameNetworkingContextHaiku();
 
     WebCore::Frame* coreFrame() const { return frame(); }
     virtual uint64_t initiatingPageID() const;
 
-    BUrlContext* context();
+    BUrlSession* session();
 
 private:
-    FrameNetworkingContextHaiku(Frame*, BUrlContext* context);
+    FrameNetworkingContextHaiku(Frame*, BUrlSession*);
     WebCore::NetworkStorageSession* storageSession() const override;
 };
 

--- a/Source/WebKitLegacy/haiku/WebCoreSupport/NotificationClientHaiku.h
+++ b/Source/WebKitLegacy/haiku/WebCoreSupport/NotificationClientHaiku.h
@@ -36,8 +36,7 @@
 
 #include <Bitmap.h>
 #include <TranslationUtils.h>
-#include <UrlProtocolRoster.h>
-#include <UrlSynchronousRequest.h>
+#include <UrlSession.h>
 
 class BWebPage;
 
@@ -61,7 +60,7 @@ public:
     void notificationObjectDestroyed(Notification*) override {}
     void notificationControllerDestroyed() override {}
 
-    void requestPermission(ScriptExecutionContext*, 
+    void requestPermission(ScriptExecutionContext*,
             RefPtr<NotificationPermissionCallback>&& callback) override {
         if (callback)
             callback->handleEvent(NotificationPermission::Granted);
@@ -74,8 +73,6 @@ public:
     }
 
 private:
-    class SynchronousListener;
-
     BNotification fromDescriptor(Notification* descriptor);
 };
 

--- a/Tools/HaikuLauncher/LauncherApp.h
+++ b/Tools/HaikuLauncher/LauncherApp.h
@@ -32,6 +32,7 @@
 #include <support/Locker.h>
 #include <Application.h>
 #include <Rect.h>
+#include <UrlSession.h>
 
 class BFile;
 class LauncherWindow;
@@ -49,13 +50,15 @@ public:
     virtual bool QuitRequested();
 
 private:
-	bool openSettingsFile(BFile& file, uint32 mode);
-	void newWindow(const BString& url);
+    bool openSettingsFile(BFile& file, uint32 mode);
+    void newWindow(const BString& url);
 
     int m_windowCount;
     BRect m_lastWindowFrame;
     BMessage* m_launchRefsMessage;
     bool m_initialized;
+
+    BUrlSession m_session;
 };
 
 extern const char* kApplicationSignature;

--- a/Tools/HaikuLauncher/LauncherWindow.cpp
+++ b/Tools/HaikuLauncher/LauncherWindow.cpp
@@ -57,9 +57,9 @@
 #include <stdio.h>
 
 enum {
-	OPEN_LOCATION = 'open',
-	OPEN_INSPECTOR = 'insp',
-	SAVE_PAGE = 'save',
+    OPEN_LOCATION = 'open',
+    OPEN_INSPECTOR = 'insp',
+    SAVE_PAGE = 'save',
     GO_BACK = 'goba',
     GO_FORWARD = 'gofo',
     STOP = 'stop',
@@ -71,21 +71,21 @@ enum {
     TEXT_SIZE_RESET = 'tsrs',
 };
 
-LauncherWindow::LauncherWindow(BRect frame, ToolbarPolicy toolbarPolicy)
+LauncherWindow::LauncherWindow(BRect frame, BUrlSession* session, ToolbarPolicy toolbarPolicy)
     : BWebWindow(frame, "HaikuLauncher",
         B_DOCUMENT_WINDOW_LOOK, B_NORMAL_WINDOW_FEEL,
         B_AUTO_UPDATE_SIZE_LIMITS | B_ASYNCHRONOUS_CONTROLS)
 {
-	init(new BWebView("web view"), toolbarPolicy);
+    init(new BWebView("web view", session), toolbarPolicy);
 }
 
 LauncherWindow::LauncherWindow(BRect frame, BWebView* webView,
-		ToolbarPolicy toolbarPolicy)
+        ToolbarPolicy toolbarPolicy)
     : BWebWindow(frame, "HaikuLauncher",
         B_DOCUMENT_WINDOW_LOOK, B_NORMAL_WINDOW_FEEL,
         B_AUTO_UPDATE_SIZE_LIMITS | B_ASYNCHRONOUS_CONTROLS)
 {
-	init(webView, toolbarPolicy);
+    init(webView, toolbarPolicy);
 }
 
 LauncherWindow::~LauncherWindow()
@@ -95,23 +95,23 @@ LauncherWindow::~LauncherWindow()
 
 void LauncherWindow::DispatchMessage(BMessage* message, BHandler* target)
 {
-	if (m_url && message->what == B_KEY_DOWN && target == m_url->TextView()) {
-		// Handle B_RETURN in the URL text control. This is the easiest
-		// way to react *only* when the user presses the return key in the
-		// address bar, as opposed to trying to load whatever is in there when
-		// the text control just goes out of focus.
-	    const char* bytes;
-	    if (message->FindString("bytes", &bytes) == B_OK
-	    	&& bytes[0] == B_RETURN) {
-	    	// Do it in such a way that the user sees the Go-button go down.
-	    	m_goButton->SetValue(B_CONTROL_ON);
-	    	UpdateIfNeeded();
-	    	m_goButton->Invoke();
-	    	snooze(1000);
-	    	m_goButton->SetValue(B_CONTROL_OFF);
-	    }
-	}
-	BWebWindow::DispatchMessage(message, target);
+    if (m_url && message->what == B_KEY_DOWN && target == m_url->TextView()) {
+        // Handle B_RETURN in the URL text control. This is the easiest
+        // way to react *only* when the user presses the return key in the
+        // address bar, as opposed to trying to load whatever is in there when
+        // the text control just goes out of focus.
+        const char* bytes;
+        if (message->FindString("bytes", &bytes) == B_OK
+            && bytes[0] == B_RETURN) {
+            // Do it in such a way that the user sees the Go-button go down.
+            m_goButton->SetValue(B_CONTROL_ON);
+            UpdateIfNeeded();
+            m_goButton->Invoke();
+            snooze(1000);
+            m_goButton->SetValue(B_CONTROL_OFF);
+        }
+    }
+    BWebWindow::DispatchMessage(message, target);
 }
 
 void LauncherWindow::MessageReceived(BMessage* message)
@@ -119,36 +119,36 @@ void LauncherWindow::MessageReceived(BMessage* message)
     switch (message->what) {
     case OPEN_LOCATION:
         if (m_url) {
-        	if (m_url->TextView()->IsFocus())
-        	    m_url->TextView()->SelectAll();
-        	else
-        	    m_url->MakeFocus(true);
+            if (m_url->TextView()->IsFocus())
+                m_url->TextView()->SelectAll();
+            else
+                m_url->MakeFocus(true);
         }
-    	break;
+        break;
     case OPEN_INSPECTOR: {
         // FIXME: wouldn't the view better be in the same window?
         BRect frame = Frame();
         frame.OffsetBy(20, 20);
-        LauncherWindow* inspectorWindow = new LauncherWindow(frame);
+        LauncherWindow* inspectorWindow = new LauncherWindow(frame, (BUrlSession*)NULL);
         inspectorWindow->Show();
 
         CurrentWebView()->SetInspectorView(inspectorWindow->CurrentWebView());
         break;
     }
-	case SAVE_PAGE: {
-		BMessage* message = new BMessage(B_SAVE_REQUESTED);
-		message->AddPointer("page", CurrentWebView()->WebPage());
-        
+    case SAVE_PAGE: {
+        BMessage* message = new BMessage(B_SAVE_REQUESTED);
+        message->AddPointer("page", CurrentWebView()->WebPage());
+
         if (m_saveFilePanel == NULL) {
-	        m_saveFilePanel = new BFilePanel(B_SAVE_PANEL, NULL, NULL,
+            m_saveFilePanel = new BFilePanel(B_SAVE_PANEL, NULL, NULL,
                 B_DIRECTORY_NODE, false);
         }
 
         m_saveFilePanel->SetSaveText(CurrentWebView()->WebPage()->MainFrameTitle());
         m_saveFilePanel->SetMessage(message);
-		m_saveFilePanel->Show();
-		break;
-	}
+        m_saveFilePanel->Show();
+        break;
+    }
 
     case RELOAD:
         CurrentWebView()->Reload();
@@ -156,7 +156,7 @@ void LauncherWindow::MessageReceived(BMessage* message)
     case GOTO_URL: {
         BString url;
         if (message->FindString("url", &url) != B_OK)
-        	url = m_url->Text();
+            url = m_url->Text();
         CurrentWebView()->LoadURL(url.String());
         break;
     }
@@ -239,12 +239,12 @@ void LauncherWindow::NewWindowRequested(const BString& url, bool primaryAction)
 }
 
 void LauncherWindow::NewPageCreated(BWebView* view, BRect windowFrame,
-	bool modalDialog, bool resizable, bool activate)
+    bool modalDialog, bool resizable, bool activate)
 {
-	if (!windowFrame.IsValid())
-		windowFrame = Frame().OffsetByCopy(10, 10);
-	LauncherWindow* window = new LauncherWindow(windowFrame, view, HaveToolbar);
-	window->Show();
+    if (!windowFrame.IsValid())
+        windowFrame = Frame().OffsetByCopy(10, 10);
+    LauncherWindow* window = new LauncherWindow(windowFrame, view, HaveToolbar);
+    window->Show();
 }
 
 void LauncherWindow::LoadNegotiating(const BString& url, BWebView* view)
@@ -256,7 +256,7 @@ void LauncherWindow::LoadNegotiating(const BString& url, BWebView* view)
 
 void LauncherWindow::LoadCommitted(const BString& url, BWebView* view)
 {
-	// This hook is invoked when the load is commited.
+    // This hook is invoked when the load is commited.
     if (m_url)
         m_url->SetText(url.String());
 
@@ -343,21 +343,21 @@ void LauncherWindow::NavigationCapabilitiesChanged(bool canGoBackward,
 
 bool
 LauncherWindow::AuthenticationChallenge(BString message, BString& inOutUser,
-	BString& inOutPassword, bool& inOutRememberCredentials,
-	uint32 failureCount, BWebView* view)
+    BString& inOutPassword, bool& inOutRememberCredentials,
+    uint32 failureCount, BWebView* view)
 {
-	AuthenticationPanel* panel = new AuthenticationPanel(Frame());
-		// Panel auto-destructs.
-	bool success = panel->getAuthentication(message, inOutUser, inOutPassword,
-		inOutRememberCredentials, failureCount > 0, inOutUser, inOutPassword,
-		&inOutRememberCredentials);
-	return success;
+    AuthenticationPanel* panel = new AuthenticationPanel(Frame());
+        // Panel auto-destructs.
+    bool success = panel->getAuthentication(message, inOutUser, inOutPassword,
+        inOutRememberCredentials, failureCount > 0, inOutUser, inOutPassword,
+        &inOutRememberCredentials);
+    return success;
 }
 
 
 void LauncherWindow::init(BWebView* webView, ToolbarPolicy toolbarPolicy)
 {
-	SetCurrentWebView(webView);
+    SetCurrentWebView(webView);
 
     if (toolbarPolicy == HaveToolbar) {
         // Menu
@@ -370,7 +370,7 @@ void LauncherWindow::init(BWebView* webView, ToolbarPolicy toolbarPolicy)
         newItem->SetTarget(be_app);
         menu->AddItem(new BMenuItem("Open location", new BMessage(OPEN_LOCATION), 'L'));
         menu->AddItem(new BMenuItem("Inspect page", new BMessage(OPEN_INSPECTOR), 'I'));
-	    menu->AddItem(new BMenuItem("Save page", new BMessage(SAVE_PAGE), 'S'));
+        menu->AddItem(new BMenuItem("Save page", new BMessage(SAVE_PAGE), 'S'));
         menu->AddSeparatorItem();
         menu->AddItem(new BMenuItem("Close", new BMessage(B_QUIT_REQUESTED), 'W', B_SHIFT_KEY));
         BMenuItem* quitItem = new BMenuItem("Quit", new BMessage(B_QUIT_REQUESTED), 'Q');

--- a/Tools/HaikuLauncher/LauncherWindow.h
+++ b/Tools/HaikuLauncher/LauncherWindow.h
@@ -43,6 +43,7 @@ class BStatusBar;
 class BStringView;
 class BTextControl;
 class BWebView;
+class BUrlSession;
 
 enum ToolbarPolicy {
     HaveToolbar,
@@ -57,7 +58,7 @@ enum {
 
 class LauncherWindow : public BWebWindow {
 public:
-    LauncherWindow(BRect frame, ToolbarPolicy = HaveToolbar);
+    LauncherWindow(BRect frame, BUrlSession*, ToolbarPolicy = HaveToolbar);
     LauncherWindow(BRect frame, BWebView* view, ToolbarPolicy = HaveToolbar);
     virtual ~LauncherWindow();
 


### PR DESCRIPTION
This PR contains the work done to adapt haikuwebkit for use with [my changes to Services Kit](https://review.haiku-os.org/q/hashtag:gsoc2020+owner:leorize%252Boss%2540disroot.org).

This PR contains the following major changes:
- A rework of the networking backend to simplify the code and fix authentication as well as redirection. Tests have been conducted against https://httpbin.org and https://jigsaw.w3.org.
- An adaption to the new [BDataIO outputs](https://review.haiku-os.org/c/haiku/+/3084). This is pretty much a PoC, and I'm quite unhappy with how complicated the locking system is.
- An basic adaption for BUrlSession. This portion of the PR is pretty WIP, only enough for HaikuLauncher to compile as tests for the new API.